### PR TITLE
Fixed a typo on one word and added a definition

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -17,7 +17,7 @@ Lederhose - short or knee-length leather breeches that are worn as traditional g
 Audi - a German automobile manufacturer that designs, engineers, produces, markets and distributes luxury vehicles.
 Schloss - a chateau, manor, or palace.
 Munich -  the capital and most populous city of Bavaria.
-wettbewerbsfachig - ??
+wettbewerbsfaehig - competitive
 Mehlhase - ??
 Gebaeck - Pastry
 Baeckerei - bakery


### PR DESCRIPTION
The word "wettbewerbsfachig" should be "wettbewerbsfaehig" after reading carefully through the Icebreaker document, and I found the word (which is actually spelt wettbewerbsfähig but typing out umlauts is hard so "ae" is used instead of "ä" (I learned German in high-school so I know a thing or two about German))  to mean "competitive" in a German-English dictionary from Cambridge dictionary (my German is rusty). 

https://dictionary.cambridge.org/dictionary/german-english/wettbewerbsfahig?q=wettbewerbsf%C3%A4hig